### PR TITLE
fix: tutorial json gen

### DIFF
--- a/examples/tutorial/README.md
+++ b/examples/tutorial/README.md
@@ -53,7 +53,7 @@ def main():
 
     data = dict(input_shapes = [shape, shape, shape],
                 input_data = [d, dy, dz],
-                public_inputs = [((o).detach().numpy()).reshape([-1]).tolist() for o in torch_out])
+                output_data = [((o).detach().numpy()).reshape([-1]).tolist() for o in torch_out])
 
     # Serialize data into file:
     json.dump( data, open( "input.json", 'w' ) )

--- a/examples/tutorial/tutorial.py
+++ b/examples/tutorial/tutorial.py
@@ -52,7 +52,7 @@ def main():
 
     data = dict(input_shapes = [shape, shape, shape],
                 input_data = [d, dy, dz],
-                public_inputs = [((o).detach().numpy()).reshape([-1]).tolist() for o in torch_out])
+                output_data = [((o).detach().numpy()).reshape([-1]).tolist() for o in torch_out])
 
     # Serialize data into file:
     json.dump( data, open( "input.json", 'w' ) )


### PR DESCRIPTION
Currently `export.py` doesn't support multiple `inputs` / `input_shapes`. Replacing the tutorial `main()` with a call to `export` would be ideal. In the interim this PR fixes some of the outdated `.json` generation in the tutorial. 

 