### PR TITLE
refactor: move notebook example to `pyezkl`

### DIFF
--- a/examples/ezkl_demo.ipynb
+++ b/examples/ezkl_demo.ipynb
@@ -1,0 +1,243 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "98499cbe",
+   "metadata": {},
+   "source": [
+    "## EZKL Jupyter Notebook Demo \n",
+    "\n",
+    "[Build the python wheels locally by following the instructions on the docs](https://docs.ezkl.xyz/python_bindings/), you will generally want to run the optimized development build command with.\n",
+    "```shell\n",
+    "maturin develop --release --features python-bindings\n",
+    "```\n",
+    "\n",
+    "Activate the virtual environment in poetry, and install the developmental version of ezkl.\n",
+    "```shell\n",
+    "poetry install      # this should fail but would initialize a virtual env for you\n",
+    "poetry shell\n",
+    "cd target/wheels\n",
+    "pip install ezkl_lib-version-pythontype-abi3-osversion-processor.whl\n",
+    "```\n",
+    "\n",
+    "Once `ezkl_lib` is installed you can install dependencies properly. After which, you'll obtain a working setup of pyezkl locally.\n",
+    "```shell\n",
+    "cd navigate-back-to-pyezkl\n",
+    "poetry install\n",
+    "\n",
+    "python\n",
+    ">>> import ezkl\n",
+    ">>> ezkl.export(...)\n",
+    "```\n",
+    "\n",
+    "To be able to export to onnx: \n",
+    "\n",
+    "```shell\n",
+    "pip install onnx\n",
+    "\n",
+    "```\n",
+    "\n",
+    "\n",
+    "💎 You should now be able to run the rest of the notebook 💎\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "95613ee9",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "================ Diagnostic Run torch.onnx.export version 2.0.1 ================\n",
+      "verbose: False, log level: Level.ERROR\n",
+      "======================= 0 NONE 0 NOTE 0 WARNING 0 ERROR ========================\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "# here we create and (potentially train a model)\n",
+    "\n",
+    "from torch import nn\n",
+    "import ezkl\n",
+    "import os\n",
+    "import json \n",
+    "\n",
+    "\n",
+    "# Defines the model\n",
+    "# we got convs, we got relu, we got linear layers \n",
+    "# What else could one want ???? \n",
+    "\n",
+    "class MyModel(nn.Module):\n",
+    "    def __init__(self):\n",
+    "        super(MyModel, self).__init__()\n",
+    "\n",
+    "        self.conv1 = nn.Conv2d(in_channels=1, out_channels=2, kernel_size=5, stride=2)\n",
+    "        self.conv2 = nn.Conv2d(in_channels=2, out_channels=3, kernel_size=5, stride=2)\n",
+    "        \n",
+    "        self.relu = nn.ReLU()\n",
+    "\n",
+    "        self.d1 = nn.Linear(48, 48)\n",
+    "        self.d2 = nn.Linear(48, 10)\n",
+    "\n",
+    "    def forward(self, x):\n",
+    "        # 32x1x28x28 => 32x32x26x26\n",
+    "        x = self.conv1(x)\n",
+    "        x = self.relu(x)\n",
+    "        x = self.conv2(x)\n",
+    "        x = self.relu(x)\n",
+    "\n",
+    "        # flatten => 32 x (32*26*26)\n",
+    "        x = x.flatten(start_dim = 1)\n",
+    "\n",
+    "        # 32 x (32*26*26) => 32x128\n",
+    "        x = self.d1(x)\n",
+    "        x = self.relu(x)\n",
+    "\n",
+    "        # logits => 32x10\n",
+    "        logits = self.d2(x)\n",
+    "       \n",
+    "        return logits\n",
+    "\n",
+    "circuit = MyModel()\n",
+    "ezkl.export(circuit, input_shape = [1,28,28])\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "id": "8b74dcee",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "params_path = os.path.join('kzg.params')\n",
+    "\n",
+    "res = ezkl.gen_srs(params_path, 17)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "id": "b1c561a8",
+   "metadata": {},
+   "outputs": [
+    {
+     "ename": "NameError",
+     "evalue": "name 'data_path' is not defined",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mNameError\u001b[0m                                 Traceback (most recent call last)",
+      "Cell \u001b[0;32mIn[15], line 13\u001b[0m\n\u001b[1;32m      9\u001b[0m circuit_params_path \u001b[38;5;241m=\u001b[39m os\u001b[38;5;241m.\u001b[39mpath\u001b[38;5;241m.\u001b[39mjoin(\u001b[38;5;124m'\u001b[39m\u001b[38;5;124mcircuit.params\u001b[39m\u001b[38;5;124m'\u001b[39m)\n\u001b[1;32m     10\u001b[0m params_path \u001b[38;5;241m=\u001b[39m os\u001b[38;5;241m.\u001b[39mpath\u001b[38;5;241m.\u001b[39mjoin(\u001b[38;5;124m'\u001b[39m\u001b[38;5;124mkzg.params\u001b[39m\u001b[38;5;124m'\u001b[39m)\n\u001b[1;32m     12\u001b[0m res \u001b[38;5;241m=\u001b[39m ezkl\u001b[38;5;241m.\u001b[39msetup(\n\u001b[0;32m---> 13\u001b[0m         \u001b[43mdata_path\u001b[49m,\n\u001b[1;32m     14\u001b[0m         model_path,\n\u001b[1;32m     15\u001b[0m         vk_path,\n\u001b[1;32m     16\u001b[0m         pk_path,\n\u001b[1;32m     17\u001b[0m         params_path,\n\u001b[1;32m     18\u001b[0m         circuit_params_path,\n\u001b[1;32m     19\u001b[0m     )\n\u001b[1;32m     21\u001b[0m \u001b[38;5;28;01massert\u001b[39;00m res \u001b[38;5;241m==\u001b[39m \u001b[38;5;28;01mTrue\u001b[39;00m\n\u001b[1;32m     22\u001b[0m \u001b[38;5;28;01massert\u001b[39;00m os\u001b[38;5;241m.\u001b[39mpath\u001b[38;5;241m.\u001b[39misfile(vk_path)\n",
+      "\u001b[0;31mNameError\u001b[0m: name 'data_path' is not defined"
+     ]
+    }
+   ],
+   "source": [
+    "\n",
+    "# HERE WE SETUP THE CIRCUIT PARAMS \n",
+    "# WE GOT KEYS \n",
+    "# WE GOT CIRCUIT PARAMETERS \n",
+    "# EVERYTHING ANYONE HAS EVER NEEDED FOR ZK \n",
+    "\n",
+    "data_path = \n",
+    "pk_path = os.path.join('test.pk')\n",
+    "vk_path = os.path.join('test.vk')\n",
+    "circuit_params_path = os.path.join('circuit.params')\n",
+    "params_path = os.path.join('kzg.params')\n",
+    "\n",
+    "res = ezkl.setup(\n",
+    "        data_path,\n",
+    "        model_path,\n",
+    "        vk_path,\n",
+    "        pk_path,\n",
+    "        params_path,\n",
+    "        circuit_params_path,\n",
+    "    )\n",
+    "\n",
+    "assert res == True\n",
+    "assert os.path.isfile(vk_path)\n",
+    "assert os.path.isfile(pk_path)\n",
+    "assert os.path.isfile(circuit_params_path)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "c384cbc8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# GENERATE A PROOF \n",
+    "proof_path = os.path.join('test.pf')\n",
+    "\n",
+    "res = ezkl_lib.prove(\n",
+    "        data_path,\n",
+    "        model_path,\n",
+    "        pk_path,\n",
+    "        proof_path,\n",
+    "        params_path,\n",
+    "        \"poseidon\",\n",
+    "        \"single\",\n",
+    "        circuit_params_path\n",
+    "    )\n",
+    "\n",
+    "assert res == True\n",
+    "assert os.path.isfile(proof_path)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "76f00d41",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# VERIFY IT \n",
+    "\n",
+    "res = ezkl_lib.verify(\n",
+    "        proof_path,\n",
+    "        circuit_params_path,\n",
+    "        vk_path,\n",
+    "        params_path,\n",
+    "    )\n",
+    "\n",
+    "assert res == True\n",
+    "print(\"verified\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4b21256d",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.2"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/examples/ezkl_demo.ipynb
+++ b/examples/ezkl_demo.ipynb
@@ -7,7 +7,7 @@
    "source": [
     "## EZKL Jupyter Notebook Demo \n",
     "\n",
-    "[Build the python wheels locally by following the instructions on the docs](https://docs.ezkl.xyz/python_bindings/), you will generally want to run the optimized development build command with.\n",
+    "[Build the python wheels locally by following the instructions on the docs](https://docs.ezkl.xyz/python_bindings/), you will generally want to run the optimized development build command with:\n",
     "```shell\n",
     "maturin develop --release --features python-bindings\n",
     "```\n",
@@ -43,7 +43,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 20,
    "id": "95613ee9",
    "metadata": {},
    "outputs": [
@@ -109,7 +109,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": null,
    "id": "8b74dcee",
    "metadata": {},
    "outputs": [],
@@ -121,22 +121,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": null,
    "id": "b1c561a8",
    "metadata": {},
-   "outputs": [
-    {
-     "ename": "NameError",
-     "evalue": "name 'data_path' is not defined",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
-      "\u001b[0;31mNameError\u001b[0m                                 Traceback (most recent call last)",
-      "Cell \u001b[0;32mIn[15], line 13\u001b[0m\n\u001b[1;32m      9\u001b[0m circuit_params_path \u001b[38;5;241m=\u001b[39m os\u001b[38;5;241m.\u001b[39mpath\u001b[38;5;241m.\u001b[39mjoin(\u001b[38;5;124m'\u001b[39m\u001b[38;5;124mcircuit.params\u001b[39m\u001b[38;5;124m'\u001b[39m)\n\u001b[1;32m     10\u001b[0m params_path \u001b[38;5;241m=\u001b[39m os\u001b[38;5;241m.\u001b[39mpath\u001b[38;5;241m.\u001b[39mjoin(\u001b[38;5;124m'\u001b[39m\u001b[38;5;124mkzg.params\u001b[39m\u001b[38;5;124m'\u001b[39m)\n\u001b[1;32m     12\u001b[0m res \u001b[38;5;241m=\u001b[39m ezkl\u001b[38;5;241m.\u001b[39msetup(\n\u001b[0;32m---> 13\u001b[0m         \u001b[43mdata_path\u001b[49m,\n\u001b[1;32m     14\u001b[0m         model_path,\n\u001b[1;32m     15\u001b[0m         vk_path,\n\u001b[1;32m     16\u001b[0m         pk_path,\n\u001b[1;32m     17\u001b[0m         params_path,\n\u001b[1;32m     18\u001b[0m         circuit_params_path,\n\u001b[1;32m     19\u001b[0m     )\n\u001b[1;32m     21\u001b[0m \u001b[38;5;28;01massert\u001b[39;00m res \u001b[38;5;241m==\u001b[39m \u001b[38;5;28;01mTrue\u001b[39;00m\n\u001b[1;32m     22\u001b[0m \u001b[38;5;28;01massert\u001b[39;00m os\u001b[38;5;241m.\u001b[39mpath\u001b[38;5;241m.\u001b[39misfile(vk_path)\n",
-      "\u001b[0;31mNameError\u001b[0m: name 'data_path' is not defined"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "\n",
     "# HERE WE SETUP THE CIRCUIT PARAMS \n",
@@ -144,7 +132,8 @@
     "# WE GOT CIRCUIT PARAMETERS \n",
     "# EVERYTHING ANYONE HAS EVER NEEDED FOR ZK \n",
     "\n",
-    "data_path = \n",
+    "data_path = os.path.join('input.json')\n",
+    "model_path = os.path.join('network.onnx')\n",
     "pk_path = os.path.join('test.pk')\n",
     "vk_path = os.path.join('test.vk')\n",
     "circuit_params_path = os.path.join('circuit.params')\n",
@@ -167,7 +156,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 18,
    "id": "c384cbc8",
    "metadata": {},
    "outputs": [],
@@ -192,10 +181,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 19,
    "id": "76f00d41",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "verified\n"
+     ]
+    }
+   ],
    "source": [
     "# VERIFY IT \n",
     "\n",


### PR DESCRIPTION
We should move the jupyter notebook to `pyezkl` such that updates to examples can be carried out alongside new feature rollouts. 