### PR TITLE
ci: overwrite version with tag

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -28,6 +28,15 @@ jobs:
       uses: abatilo/actions-poetry@v2
       with:
         poetry-version: 1.4.2
+
+    - name: Update pyproject.toml version to tag used for the build
+      run: |
+          TAG=${{ github.ref }}
+          TAG=${TAG#refs/tags/}
+          TAG=${TAG#v}
+          sed -i "s/^version = \".*\"/version = \"$TAG\"/" pyproject.toml
+          cat pyproject.toml
+
     - name: Install dependencies
       run: poetry install
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ezkl"
-version = "0.0.3"
+version = "0.0.4"
 description = "Easy zero-knowledge learning in Python"
 authors = [
   "Jason Morton <jason@zkonduit.com>",


### PR DESCRIPTION
Changes:
1. The build step will overwrite the pyproject.toml file with the tag version on github. Tag version is the authoritative source of truth. Note that the `v` prefix in `v0.0.1` will be omitted to conform to the same convention already being used.
2. Upgrades the version manually 